### PR TITLE
Compatibility and Performance

### DIFF
--- a/ckanext/embeddings/actions.py
+++ b/ckanext/embeddings/actions.py
@@ -1,7 +1,7 @@
 from ckan.plugins import toolkit
 
-from ckanext.embeddings.backends import get_embeddings_backend
-
+import logging
+log = logging.getLogger(__name__)
 
 @toolkit.side_effect_free
 def package_similar_show(context, data_dict):

--- a/ckanext/embeddings/backends.py
+++ b/ckanext/embeddings/backends.py
@@ -13,7 +13,6 @@ log = logging.getLogger(__name__)
 
 class BaseEmbeddingsBackend:
     def get_dataset_values(self, dataset_dict):
-
         if dataset_dict.get("notes"):
             return dataset_dict["title"] + " " + dataset_dict["notes"]
         else:

--- a/ckanext/embeddings/backends.py
+++ b/ckanext/embeddings/backends.py
@@ -101,7 +101,12 @@ embeddings_backends = {}
 
 def _load_embeddings_backends():
     from importlib.metadata import entry_points
-    for ep in entry_points(group="ckanext.embeddings.backends"):
+    try:
+        eps = entry_points(group="ckanext.embeddings.backends")
+    except:
+        # python 3.9/3.8
+        eps = (ep for ep in entry_points()['ckanext.embeddings.backends'])
+    for ep in eps:
         embeddings_backends[ep.name] = ep.load()
         log.debug(f"Registering Embeddings Backend: {ep.name}")
 

--- a/ckanext/embeddings/backends.py
+++ b/ckanext/embeddings/backends.py
@@ -105,15 +105,21 @@ def _load_embeddings_backends():
         embeddings_backends[ep.name] = ep.load()
         log.debug(f"Registering Embeddings Backend: {ep.name}")
 
+_embeddings_backend = None
 
 def get_embeddings_backend():
-
     # TODO: config declaration
-
+    global _embeddings_backend
     backend = toolkit.config.get("ckanext.embeddings.backend", "sentence_transformers")
 
     log.debug(f"Using Embeddings Backend: {backend}")
-    return embeddings_backends[backend]()
+    import time
+    start = time.time()
+    try:
+        _load_embeddings_backends()
+        if _embeddings_backend is None:
+            _embeddings_backend = embeddings_backends[backend]()
+        return _embeddings_backend
+    finally:
+        log.debug("loading embeddings took: %.3f sec", time.time()-start)
 
-
-_load_embeddings_backends()

--- a/ckanext/embeddings/cli.py
+++ b/ckanext/embeddings/cli.py
@@ -66,3 +66,10 @@ def search(query: str, limit: int):
     for r in result["results"]:
 
         print(f"{r['id']} - {r['title']}")
+
+
+@embeddings.command()
+def load():
+    """ Loads the backend embeddings, filling whatever cache is required, downloading models, etc """
+    backend = get_embeddings_backend()
+

--- a/ckanext/embeddings/plugin.py
+++ b/ckanext/embeddings/plugin.py
@@ -70,6 +70,9 @@ class EmbeddingPlugin(plugins.SingletonPlugin):
 
         return dataset_dict
 
+    def before_index(self, dataset_dict):
+        return self.before_dataset_index(dataset_dict)
+
     def before_dataset_search(self, search_params):
         extras = search_params.get("extras", {})
         if isinstance(extras, str):
@@ -102,3 +105,6 @@ class EmbeddingPlugin(plugins.SingletonPlugin):
         search_params["q"] = f"{{!knn f={field_name} topK={rows}}}{list(embedding)}"
 
         return search_params
+
+    def before_search(self, search_params):
+        return self.before_dataset_search(search_params)

--- a/ckanext/embeddings/plugin.py
+++ b/ckanext/embeddings/plugin.py
@@ -20,14 +20,17 @@ class EmbeddingPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IPackageController, inherit=True)
 
-    backend = None
+    _backend = None
+
+    @property
+    def backend(self):
+        if self._backend is None:
+            self._backend = get_embeddings_backend()
+        return self._backend
 
     # IConfigurer
 
     def update_config(self, config):
-
-        self.backend = get_embeddings_backend()
-
         toolkit.add_template_directory(config, "templates")
         toolkit.add_resource("assets", "ckanext-embeddings")
 
@@ -57,8 +60,6 @@ class EmbeddingPlugin(plugins.SingletonPlugin):
 
         dataset_id = dataset_dict["id"]
 
-        if not self.backend:
-            self.backend = get_embeddings_backend()
         dataset_embedding = self.backend.get_embedding_for_dataset(dataset_dict)
 
         if dataset_embedding is not None:


### PR DESCRIPTION
(let me know if you'd prefer separate PRs, this is a snapshot of some updates at the moment)

* Compatibility 
  * the importlib interface changed in 3.10, this allows 3.8/9 to load the entrypoints.
  * Added before index/before search hooks for Ckan2.9
  * Lazy loading of modules is required to work in uwsgi, in multi-worker mode, without using lazy-apps. And lazy-apps is really slow to reload because there's a thundering herd of all of the workers loading all of the imports at once.
* Performance: 
  * Don't recalculate embeddings for dataset similarity, just read them from SOLR. This means we don't actually have to load the backend for similarity search, making it way faster.
  * Lazy loading backends allows CKAN to start up without taking 3 seconds to load the model. 
  * A CLI command to load the backend, forcing the backend to download the models at one specific time, rather than "sometime" when everything starts. 